### PR TITLE
Client context update

### DIFF
--- a/lib/feature_state.rb
+++ b/lib/feature_state.rb
@@ -1,7 +1,7 @@
 require_relative 'strategy'
 
 class FeatureState
-	attr_reader :value
+	attr_reader :value, :strategy
 	def initialize(feature_state_object)
 		@title = feature_state_object[:title],
 		@value = feature_state_object[:value],

--- a/lib/pioneer_ruby_sdk.rb
+++ b/lib/pioneer_ruby_sdk.rb
@@ -52,3 +52,20 @@ class Pioneer_Ruby_Sdk
 		@client.get_feature(key, default_value)
 	end
 end
+
+sdk_client = Pioneer_Ruby_Sdk.new('http://localhost:3030/features', 'a14dcd5b-fcdc-49eb-9cee-2d84dac21d9c')
+
+sdk_connection = sdk_client.connect.with_wait_for_data
+
+puts sdk_connection
+puts 'What is the current state of `test this flag`?'
+puts sdk_connection.get_feature('test this flag', true) # should log `false`
+
+sdk_with_user = sdk_connection.with_context('99')
+if sdk_with_user.get_feature('test this flag', true)
+	puts 'Calling some microservice...'
+	# call to new microservice goes here
+else
+	puts 'Calling the monolith service...'
+	# monolith defined service call goes here
+end

--- a/lib/pioneer_ruby_sdk.rb
+++ b/lib/pioneer_ruby_sdk.rb
@@ -52,20 +52,3 @@ class Pioneer_Ruby_Sdk
 		@client.get_feature(key, default_value)
 	end
 end
-
-sdk_client = Pioneer_Ruby_Sdk.new('http://localhost:3030/features', 'a14dcd5b-fcdc-49eb-9cee-2d84dac21d9c')
-
-sdk_connection = sdk_client.connect.with_wait_for_data
-
-puts sdk_connection
-puts 'What is the current state of `test this flag`?'
-puts sdk_connection.get_feature('test this flag', true) # should log `false`
-
-sdk_with_user = sdk_connection.with_context('99')
-if sdk_with_user.get_feature('test this flag', true)
-	puts 'Calling some microservice...'
-	# call to new microservice goes here
-else
-	puts 'Calling the monolith service...'
-	# monolith defined service call goes here
-end

--- a/lib/pioneer_ruby_sdk.rb
+++ b/lib/pioneer_ruby_sdk.rb
@@ -2,7 +2,8 @@ require_relative 'event_source_client'
 require_relative 'context'
 require_relative 'client_with_context'
 
-class Pioneer_Ruby_Sdk
+# wrapper for event source client
+class PioneerRubySdk
 	def initialize(server_address, sdk_key)
 		@server_address = server_address
 		@sdk_key = sdk_key

--- a/lib/strategy.rb
+++ b/lib/strategy.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
+# handles the calculation of rollout for a given context
 class Strategy
   def initialize(percentage)
 		@percentage = percentage
 		@modulus = 100
 	end
-
 
 	def calculate(context)
 		key = context.get_key()
@@ -13,6 +15,6 @@ class Strategy
 
 	def get_hash_based_percentage(string) 
 		sum = string.bytes.sum()
-		return  ((sum % @modulus) + 1)
+		return ((sum % @modulus) + 1)
 	end
 end

--- a/lib/strategy.rb
+++ b/lib/strategy.rb
@@ -13,6 +13,7 @@ class Strategy
 
 	def get_hash_based_percentage(string) 
 		sum = string.bytes.sum()
-		return  ((sum % @modulus) + 1) / @modulus
+		puts "sum of bytes: ", Float((sum % @modulus) + 1)
+		return  ((sum % @modulus) + 1)
 	end
 end

--- a/lib/strategy.rb
+++ b/lib/strategy.rb
@@ -13,7 +13,6 @@ class Strategy
 
 	def get_hash_based_percentage(string) 
 		sum = string.bytes.sum()
-		puts "sum of bytes: ", Float((sum % @modulus) + 1)
 		return  ((sum % @modulus) + 1)
 	end
 end


### PR DESCRIPTION
Updates to address the percentage rollout implementation; previously, due to a division error, all clients with context would execute the rollout regardless of value passed in for hashing.
Additionally, small additions in the form of comments and spacing to move closer to convention.