### PR TITLE
updated timer to utilize jitter in reconnects

### DIFF
--- a/lib/pioneer_ruby_sdk.rb
+++ b/lib/pioneer_ruby_sdk.rb
@@ -19,7 +19,7 @@ class PioneerRubySdk
 		self
 	end
 
-	def with_wait_for_data(time_out = 1, polling_attempts = 5)
+	def with_wait_for_data(time_out = 1, polling_attempts = 10)
 		attempts = 0
 
 		until @client.has_data() do
@@ -29,7 +29,7 @@ class PioneerRubySdk
 				break
 			end
 
-			sleep(time_out)
+			sleep(time_out * rand(10))
 		end
 		return self
 	end


### PR DESCRIPTION
Reconnect logic now uses random number generation to add jitter to reconnection attempts in `PioneerRubySDK.with_wait_for_data`.
